### PR TITLE
[FEAT] 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/example/banthing/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/banthing/domain/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.example.banthing.domain.user.controller;
+
+import com.example.banthing.domain.user.service.KakaoService;
+import com.example.banthing.global.common.ApiResponse;
+import com.example.banthing.global.security.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.banthing.global.common.ApiResponse.successWithNoContent;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping("/user/kakao/callback")
+    public ResponseEntity<ApiResponse<?>> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+
+        String token = kakaoService.kakaoLogin(code);
+
+        // Cookie 생성 및 직접 브라우저에 Set
+        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, token.substring(7));
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().body(successWithNoContent());
+    }
+}

--- a/src/main/java/com/example/banthing/domain/user/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/banthing/domain/user/dto/KakaoUserInfoDto.java
@@ -1,0 +1,18 @@
+package com.example.banthing.domain.user.dto;
+
+import com.example.banthing.domain.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String email;
+
+    public KakaoUserInfoDto(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/example/banthing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/banthing/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.banthing.domain.user.repository;
+
+import com.example.banthing.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findBySocialId(Long socialId);
+}

--- a/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
+++ b/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
@@ -1,0 +1,136 @@
+package com.example.banthing.domain.user.service;
+
+import com.example.banthing.domain.user.entity.LoginType;
+import com.example.banthing.domain.user.repository.UserRepository;
+import com.example.banthing.domain.user.dto.KakaoUserInfoDto;
+import com.example.banthing.domain.user.entity.User;
+import com.example.banthing.global.security.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j(topic = "KAKAO Login")
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+    private final JwtUtil jwtUtil;
+
+    @Value("${kakao.apikey}")
+    private String apiKey;
+
+    @Value("${kakao.redirect-uri}") // Base64 Encode 한 SecretKey
+    private String redirectUri;
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+
+        String accessToken = getToken(code);
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        return jwtUtil.createToken(String.valueOf(kakaoUser.getId()));
+    }
+
+    // 액세스 토큰 요청
+    private String getToken(String code) throws JsonProcessingException {
+
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", apiKey);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    // 사용자 정보 요청
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        log.info("accessToken : " + accessToken);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + " " + email);
+        return new KakaoUserInfoDto(id, email);
+    }
+
+    // 회원가입 처리
+    private User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findBySocialId(kakaoId).orElse(null);
+
+        // 신규 회원가입
+        if (kakaoUser == null) {
+            String email = kakaoUserInfo.getEmail();
+
+            kakaoUser = User.builder()
+                    .nickname("반띵#" + kakaoUserInfo.getId())
+                    .email(email)
+                    .loginType(LoginType.kakao)
+                    .build();
+
+            userRepository.save(kakaoUser);
+        }
+        return kakaoUser;
+    }
+}

--- a/src/main/java/com/example/banthing/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/banthing/global/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.example.banthing.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig  {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofSeconds(5)) // 5초
+                .setReadTimeout(Duration.ofSeconds(5)) // 5초
+                .build();
+    }
+}

--- a/src/main/java/com/example/banthing/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/banthing/global/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.example.banthing.global.config;
+;
+import com.example.banthing.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/",
+            "/user/kakao/callback"
+    };
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> {
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                });
+
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/banthing/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/banthing/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.example.banthing.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String token = jwtUtil.getTokenFromRequest(request);
+
+        if (StringUtils.hasText(token)) {
+
+            // JWT 토큰 substring
+            log.info(token);
+
+            if (!jwtUtil.validateToken(token)) {
+                log.error("Token Error");
+                return;
+            }
+
+            String userId = jwtUtil.getUserInfoFromToken(token).getSubject();
+            log.info("userId : " + userId);
+
+            try {
+                setAuthentication(userId);
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    // 인증 처리
+    public void setAuthentication(String userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(userId);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String userId) {
+        return new UsernamePasswordAuthenticationToken(userId, null, null);
+    }
+}

--- a/src/main/java/com/example/banthing/global/security/JwtUtil.java
+++ b/src/main/java/com/example/banthing/global/security/JwtUtil.java
@@ -1,0 +1,123 @@
+package com.example.banthing.global.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    // Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // 사용자 권한 값의 KEY
+    public static final String AUTHORIZATION_KEY = "auth";
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+    // 토큰 만료시간
+    private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    // 로그 설정
+    public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // 토큰 생성
+    public String createToken(String userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(userId) // 사용자 식별자값(ID)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    // JWT Cookie 에 저장
+    public void addJwtToCookie(String token, HttpServletResponse res) {
+        try {
+            token = URLEncoder.encode(token, "utf-8").replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
+
+            Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token); // Name-Value
+            cookie.setPath("/");
+
+            // Response 객체에 Cookie 추가
+            res.addCookie(cookie);
+        } catch (UnsupportedEncodingException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    // JWT 토큰 substring
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        logger.error("Not Found Token");
+        throw new NullPointerException("Not Found Token");
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 가져오기
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    // HttpServletRequest 에서 JWT 토큰이 담긴 쿠키 값을 가져오는 메소드.
+    public String getTokenFromRequest(HttpServletRequest req) {
+        Cookie[] cookies = req.getCookies();
+        if(cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+                    try {
+                        return URLDecoder.decode(cookie.getValue(), "UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        return null;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 

## 📝작업 내용

> 카카오 로그인 구현과 JWT 인증 로직을 추가하였습니다.

- 카카오 로그인이 성공하면, 쿠키에 JWT 토큰이 담기고, success 응답값이 반환됩니다.
- 첫 로그인시, 회원가입이 진행되며, 사용자 이름은 랜덤 설정됩니다.
- 프로필 랜덤 설정 부분은 구현되지 않았습니다. (추후 구현 예정)
