### PR TITLE
[FIX]] 중복 회원 가입 해결

### DIFF
--- a/src/main/java/com/example/banthing/domain/user/entity/User.java
+++ b/src/main/java/com/example/banthing/domain/user/entity/User.java
@@ -22,8 +22,10 @@ public class User extends Timestamped {
 
     private String nickname;
 
+    @Column(unique = true, nullable = false)
     private Long socialId;
 
+    @Column(unique = true, nullable = false)
     private String email;
 
     @OneToOne

--- a/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
+++ b/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
@@ -131,6 +131,7 @@ public class KakaoService {
             kakaoUser = User.builder()
                     .nickname("반띵#" + kakaoUserInfo.getId())
                     .email(email)
+                    .socialId(kakaoId)
                     .profileImg(getRandomDefaultProfileImage())
                     .loginType(LoginType.kakao)
                     .build();


### PR DESCRIPTION
- social_id 를 저장하여 해결

## #️⃣연관된 이슈

> #17 

## 📝작업 내용

> social_id 를 저장하지 않아, 동일한 회원이 중복으로 가입되는 문제 발생

- social_id 를 저장하고, social_id 를 통해 가입된 회원인지 판단하도록 하였습니다.
- social_id 와 email 필드에 유니크 제약조건을 설정하였습니다.
