### PR TITLE
[FEAT] 구매목록 수정 및 최신순 정렬

### DIFF
--- a/src/main/java/com/example/banthing/domain/user/dto/PurchaseResponseDto.java
+++ b/src/main/java/com/example/banthing/domain/user/dto/PurchaseResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.banthing.domain.user.dto;
 
+import com.example.banthing.domain.chat.entity.Chatroom;
 import com.example.banthing.domain.item.entity.Item;
 import lombok.Getter;
 
@@ -16,7 +17,8 @@ public class PurchaseResponseDto {
     private final String address;
     private final LocalDateTime updatedAt;
 
-    public PurchaseResponseDto(Item item) {
+    public PurchaseResponseDto(Chatroom chatroom) {
+        Item item = chatroom.getItem();
         this.itemId = item.getId();
         this.title = item.getTitle();
         this.price = item.getPrice();

--- a/src/main/java/com/example/banthing/domain/user/entity/User.java
+++ b/src/main/java/com/example/banthing/domain/user/entity/User.java
@@ -79,25 +79,4 @@ public class User extends Timestamped {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
-
-    public void addPurchase(Item item) {
-        this.purchases.add(item);
-        item.setBuyer(this);
-    }
-
-    public void addSale(Item item) {
-        this.sales.add(item);
-        item.setSeller(this);
-    }
-
-    public void addBuyerChat(Chatroom chatroom) {
-        this.buyerChats.add(chatroom);
-        chatroom.setBuyer(this);
-    }
-
-    public void addSellerChat(Chatroom chatroom) {
-        this.sellerChats.add(chatroom);
-        chatroom.setSeller(this);
-    }
-
 }

--- a/src/main/java/com/example/banthing/domain/user/service/UserService.java
+++ b/src/main/java/com/example/banthing/domain/user/service/UserService.java
@@ -5,12 +5,14 @@ import com.example.banthing.domain.user.entity.ProfileImage;
 import com.example.banthing.domain.user.entity.User;
 import com.example.banthing.domain.user.repository.ProfileRepository;
 import com.example.banthing.domain.user.repository.UserRepository;
+import com.example.banthing.global.common.Timestamped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -49,12 +51,16 @@ public class UserService {
 
     public List<PurchaseResponseDto> findPurchasesById(Long userId) {
         User user = findById(userId);
-        return user.getPurchases().stream().map(PurchaseResponseDto::new).toList();
+        return user.getBuyerChats().stream()
+                .sorted(Comparator.comparing(chat -> chat.getItem().getCreatedAt(), Comparator.reverseOrder()))
+                .map(PurchaseResponseDto::new).toList();
     }
 
     public List<SalesResponseDto> findSalesById(Long userId) {
         User user = findById(userId);
-        return user.getSales().stream().map(SalesResponseDto::new).toList();
+        return user.getSales().stream()
+                .sorted(Comparator.comparing(Timestamped::getCreatedAt, Comparator.reverseOrder()))
+                .map(SalesResponseDto::new).toList();
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

1. 구매 목록 반환값을 채팅 구매자 기준으로 수정하였습니다.
2. 구매, 판매 목록을 조회할 떄 최신순으로 정렬되어 반환하도록 수정하였습니다.
