### PR TITLE
[FEAT] 프론트 연동용 카카오 로그인

### DIFF
--- a/src/main/java/com/example/banthing/domain/user/controller/KakaoController.java
+++ b/src/main/java/com/example/banthing/domain/user/controller/KakaoController.java
@@ -20,12 +20,23 @@ public class KakaoController {
 
     private final KakaoService kakaoService;
 
+    @GetMapping("/user/kakao")
+    public ResponseEntity<ApiResponse<?>> kakaoLogin(@RequestParam String token, HttpServletResponse response) throws JsonProcessingException {
+
+        String jwt = kakaoService.kakaoLogin(token);
+
+        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, jwt.substring(7));
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().body(successWithNoContent());
+    }
+
     @GetMapping("/user/kakao/callback")
-    public ResponseEntity<ApiResponse<?>> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+    public ResponseEntity<ApiResponse<?>> kakaoLoginForBe(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
 
-        String token = kakaoService.kakaoLogin(code);
+        String token = kakaoService.kakaoLoginForBe(code);
 
-        // Cookie 생성 및 직접 브라우저에 Set
         Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, token.substring(7));
         cookie.setPath("/");
         response.addCookie(cookie);

--- a/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
+++ b/src/main/java/com/example/banthing/domain/user/service/KakaoService.java
@@ -1,11 +1,11 @@
 package com.example.banthing.domain.user.service;
 
+import com.example.banthing.domain.user.dto.KakaoUserInfoDto;
 import com.example.banthing.domain.user.entity.LoginType;
 import com.example.banthing.domain.user.entity.ProfileImage;
+import com.example.banthing.domain.user.entity.User;
 import com.example.banthing.domain.user.repository.ProfileRepository;
 import com.example.banthing.domain.user.repository.UserRepository;
-import com.example.banthing.domain.user.dto.KakaoUserInfoDto;
-import com.example.banthing.domain.user.entity.User;
 import com.example.banthing.global.security.JwtUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -42,7 +42,15 @@ public class KakaoService {
     @Value("${kakao.redirect-uri}") // Base64 Encode 한 SecretKey
     private String redirectUri;
 
-    public String kakaoLogin(String code) throws JsonProcessingException {
+    public String kakaoLogin(String accessToken) throws JsonProcessingException {
+
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        return jwtUtil.createToken(String.valueOf(kakaoUser.getId()));
+    }
+
+    public String kakaoLoginForBe(String code) throws JsonProcessingException {
 
         String accessToken = getToken(code);
         KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);

--- a/src/main/java/com/example/banthing/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/banthing/global/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/",
-            "/user/kakao/callback",
+            "/user/kakao/**",
             "/image/upload",
             "/ws/chat/**",
             "/items"


### PR DESCRIPTION
## 📝작업 내용

> 카카오 로그인시 프론트에서 인가코드와 엑세스 토큰을 발급받은 뒤, 엑세스 토큰을 서버로 넘겨주는 방식으로 수정하였습니다.

> 프론트에서 인가코드를 받아 넘겨주는 경우, KOE303 (인가 코드 요청과 액세스 토큰 요청 시 사용한 redirect_uri가 서로 다른 경우) 에러가 발생하였기 때문입니다.

> 기존 코드는 그대로 유지하였으니, 백엔드에서 로그인 테스트할 경우 기존방식으로 진행하시면 됩니다.