### PR TITLE
[FIX] 인증 필요한 요청경로 수정

### DIFF
--- a/src/main/java/com/example/banthing/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/banthing/global/config/SecurityConfig.java
@@ -4,9 +4,10 @@ import com.example.banthing.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -27,34 +28,39 @@ public class SecurityConfig {
             "/user/kakao/**",
             "/image/upload",
             "/ws/chat/**",
-            "/items"
+            "/items/**"
     };
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf
-                        .ignoringRequestMatchers(new AntPathRequestMatcher("/user/kakao"))
-                );
-        http.cors(Customizer.withDefaults());
-        http.sessionManagement(sessionManagement ->
-                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        );
+                        .ignoringRequestMatchers(new AntPathRequestMatcher("/user/kakao/**"))
+                )
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> {
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                });
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.requestMatchers(HttpMethod.POST, "/items").authenticated();
+                    auth.requestMatchers(HttpMethod.PATCH, "/items/**").authenticated();
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
-
+    
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:5173"); // allow react server
-        config.addAllowedOrigin("http://localhost:7000"); // allow python server
-        config.addAllowedOrigin("http://localhost:3306"); // allow mysql server
+//        config.addAllowedOrigin("http://localhost:5173"); // allow react server
+//        config.addAllowedOrigin("http://localhost:7000"); // allow python server
+//        config.addAllowedOrigin("http://localhost:3306"); // allow mysql server
+        config.addAllowedOriginPattern("*");
         config.addAllowedMethod("*"); // Allow all HTTP methods
         config.addAllowedHeader("*"); // Allow all headers
         config.setAllowCredentials(true); // Allow credentials (cookies, authorization headers, etc.)


### PR DESCRIPTION
## 📝작업 내용

> GET /items와 GET /items/{id}는 인증이 필요하지 않습니다.

> POST /items, PATCH /items/{id} 은 인증이 필요합니다.

> REST API를 사용하는 /user/kakao/** 에 대해서는 CSRF 검사를 생략하도로 수정하였습니다.
